### PR TITLE
chore: habilita Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adiciona `.github/dependabot.yml` com version updates semanais (grouped), espelhando a adequacao do Dependabot na org. Toggles de alerts e security updates ja habilitados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)